### PR TITLE
fix typo in examples: CompleteActionStatus -> CompletedActionStatus

### DIFF
--- a/0.4/example-hutch/data/ro-crate-metadata.json
+++ b/0.4/example-hutch/data/ro-crate-metadata.json
@@ -111,7 +111,7 @@
         {
             "@id": "#execute-43a74be3-c175-4fe6-a13d-b9f0dca3c0fc",
             "@type": "CreateAction",
-            "actionStatus": "http://schema.org/CompleteActionStatus",
+            "actionStatus": "http://schema.org/CompletedActionStatus",
             "startTime": "2023-05-03T13:53:49.012349+00:00",
             "endTime": "2023-05-03T13:53:53.715480+00:00",
             "agent": {
@@ -153,7 +153,9 @@
         {
             "@id": "outputs/ro-crate-metadata.json#30494e22-a2fd-4d3c-945b-35f1b458eda9",
             "@type": "CreateAction",
-            "subjectOf": {"@id": "outputs/"}
+            "subjectOf": {
+                "@id": "outputs/"
+            }
         },
         {
             "@id": "#project-065c9577-dd40-4cb2-bbc7-354e34ef37de",

--- a/0.4/example-hutch/data/ro-crate-preview.html
+++ b/0.4/example-hutch/data/ro-crate-preview.html
@@ -137,7 +137,7 @@
     {
       "@id": "#execute-43a74be3-c175-4fe6-a13d-b9f0dca3c0fc",
       "@type": "CreateAction",
-      "actionStatus": "http://schema.org/CompleteActionStatus",
+      "actionStatus": "http://schema.org/CompletedActionStatus",
       "startTime": "2023-05-03T13:53:49.012349+00:00",
       "endTime": "2023-05-03T13:53:53.715480+00:00",
       "agent": {
@@ -799,7 +799,7 @@ table.table {
             <td style='text-align:left'><span>CreateAction</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">actionStatus<span>&nbsp;</span><a href="http://schema.org/actionStatus">[?]</a></th>
-            <td style='text-align:left'><a href="http://schema.org/CompleteActionStatus">http://schema.org/CompleteActionStatus</a></td>
+            <td style='text-align:left'><a href="http://schema.org/CompletedActionStatus">http://schema.org/CompletedActionStatus</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">startTime<span>&nbsp;</span><a href="http://schema.org/startTime">[?]</a></th>
             <td style='text-align:left'><span>2023-05-03T13:53:49.012349+00:00</span></td>

--- a/0.4/example-result/data/index.html
+++ b/0.4/example-result/data/index.html
@@ -112,7 +112,7 @@
     {
       "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
       "@type": "CreateAction",
-      "actionStatus": "http://schema.org/CompleteActionStatus",
+      "actionStatus": "http://schema.org/CompletedActionStatus",
       "agent": {
         "@id": "https://orcid.org/0000-0001-9842-9718"
       },
@@ -691,7 +691,7 @@ table.table {
             <td style='text-align:left'><span>CreateAction</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">actionStatus<span>&nbsp;</span><a href="http://schema.org/actionStatus">[?]</a></th>
-            <td style='text-align:left'><a href="http://schema.org/CompleteActionStatus">http://schema.org/CompleteActionStatus</a></td>
+            <td style='text-align:left'><a href="http://schema.org/CompletedActionStatus">http://schema.org/CompletedActionStatus</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">agent<span>&nbsp;</span><a href="http://schema.org/agent">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//orcid.org/0000-0001-9842-9718">Stian Soiland-Reyes</a></td>

--- a/0.4/example-result/data/ro-crate-metadata.json
+++ b/0.4/example-result/data/ro-crate-metadata.json
@@ -97,7 +97,7 @@
         {
             "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
             "@type": "CreateAction",
-            "actionStatus": "http://schema.org/CompleteActionStatus",
+            "actionStatus": "http://schema.org/CompletedActionStatus",
             "agent": {
                 "@id": "https://orcid.org/0000-0001-9842-9718"
             },
@@ -151,7 +151,7 @@
             "@type": "PropertyValue",
             "name": "tre72",
             "value": "project81"
-        },        
+        },
         {
             "@id": "input1.txt",
             "@type": "File",

--- a/0.4/example-result/data/ro-crate-preview.html
+++ b/0.4/example-result/data/ro-crate-preview.html
@@ -112,7 +112,7 @@
     {
       "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
       "@type": "CreateAction",
-      "actionStatus": "http://schema.org/CompleteActionStatus",
+      "actionStatus": "http://schema.org/CompletedActionStatus",
       "agent": {
         "@id": "https://orcid.org/0000-0001-9842-9718"
       },
@@ -691,7 +691,7 @@ table.table {
             <td style='text-align:left'><span>CreateAction</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">actionStatus<span>&nbsp;</span><a href="http://schema.org/actionStatus">[?]</a></th>
-            <td style='text-align:left'><a href="http://schema.org/CompleteActionStatus">http://schema.org/CompleteActionStatus</a></td>
+            <td style='text-align:left'><a href="http://schema.org/CompletedActionStatus">http://schema.org/CompletedActionStatus</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">agent<span>&nbsp;</span><a href="http://schema.org/agent">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//orcid.org/0000-0001-9842-9718">Stian Soiland-Reyes</a></td>

--- a/0.5-DRAFT/example-hutch/data/ro-crate-metadata.json
+++ b/0.5-DRAFT/example-hutch/data/ro-crate-metadata.json
@@ -111,7 +111,7 @@
         {
             "@id": "#execute-43a74be3-c175-4fe6-a13d-b9f0dca3c0fc",
             "@type": "CreateAction",
-            "actionStatus": "http://schema.org/CompleteActionStatus",
+            "actionStatus": "http://schema.org/CompletedActionStatus",
             "startTime": "2023-05-03T13:53:49.012349+00:00",
             "endTime": "2023-05-03T13:53:53.715480+00:00",
             "agent": {
@@ -153,7 +153,9 @@
         {
             "@id": "outputs/ro-crate-metadata.json#30494e22-a2fd-4d3c-945b-35f1b458eda9",
             "@type": "CreateAction",
-            "subjectOf": {"@id": "outputs/"}
+            "subjectOf": {
+                "@id": "outputs/"
+            }
         },
         {
             "@id": "#project-065c9577-dd40-4cb2-bbc7-354e34ef37de",

--- a/0.5-DRAFT/example-hutch/data/ro-crate-preview.html
+++ b/0.5-DRAFT/example-hutch/data/ro-crate-preview.html
@@ -139,7 +139,7 @@
     {
       "@id": "#execute-43a74be3-c175-4fe6-a13d-b9f0dca3c0fc",
       "@type": "CreateAction",
-      "actionStatus": "http://schema.org/CompleteActionStatus",
+      "actionStatus": "http://schema.org/CompletedActionStatus",
       "startTime": "2023-05-03T13:53:49.012349+00:00",
       "endTime": "2023-05-03T13:53:53.715480+00:00",
       "agent": {
@@ -795,7 +795,7 @@ table.table {
             <td style='text-align:left'><span>CreateAction</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">actionStatus<span>&nbsp;</span><a href="http://schema.org/actionStatus">[?]</a></th>
-            <td style='text-align:left'><a href="http://schema.org/CompleteActionStatus">http://schema.org/CompleteActionStatus</a></td>
+            <td style='text-align:left'><a href="http://schema.org/CompletedActionStatus">http://schema.org/CompletedActionStatus</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">startTime<span>&nbsp;</span><a href="http://schema.org/startTime">[?]</a></th>
             <td style='text-align:left'><span>2023-05-03T13:53:49.012349+00:00</span></td>

--- a/0.5-DRAFT/example-result/data/index.html
+++ b/0.5-DRAFT/example-result/data/index.html
@@ -112,7 +112,7 @@
     {
       "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
       "@type": "CreateAction",
-      "actionStatus": "http://schema.org/CompleteActionStatus",
+      "actionStatus": "http://schema.org/CompletedActionStatus",
       "agent": {
         "@id": "https://orcid.org/0000-0001-9842-9718"
       },
@@ -691,7 +691,7 @@ table.table {
             <td style='text-align:left'><span>CreateAction</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">actionStatus<span>&nbsp;</span><a href="http://schema.org/actionStatus">[?]</a></th>
-            <td style='text-align:left'><a href="http://schema.org/CompleteActionStatus">http://schema.org/CompleteActionStatus</a></td>
+            <td style='text-align:left'><a href="http://schema.org/CompletedActionStatus">http://schema.org/CompletedActionStatus</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">agent<span>&nbsp;</span><a href="http://schema.org/agent">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//orcid.org/0000-0001-9842-9718">Stian Soiland-Reyes</a></td>

--- a/0.5-DRAFT/example-result/data/ro-crate-metadata.json
+++ b/0.5-DRAFT/example-result/data/ro-crate-metadata.json
@@ -97,7 +97,7 @@
         {
             "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
             "@type": "CreateAction",
-            "actionStatus": "http://schema.org/CompleteActionStatus",
+            "actionStatus": "http://schema.org/CompletedActionStatus",
             "agent": {
                 "@id": "https://orcid.org/0000-0001-9842-9718"
             },
@@ -151,7 +151,7 @@
             "@type": "PropertyValue",
             "name": "tre72",
             "value": "project81"
-        },        
+        },
         {
             "@id": "input1.txt",
             "@type": "File",

--- a/0.5-DRAFT/example-result/data/ro-crate-preview.html
+++ b/0.5-DRAFT/example-result/data/ro-crate-preview.html
@@ -114,7 +114,7 @@
     {
       "@id": "#query-37252371-c937-43bd-a0a7-3680b48c0538",
       "@type": "CreateAction",
-      "actionStatus": "http://schema.org/CompleteActionStatus",
+      "actionStatus": "http://schema.org/CompletedActionStatus",
       "agent": {
         "@id": "https://orcid.org/0000-0001-9842-9718"
       },
@@ -688,7 +688,7 @@ table.table {
             <td style='text-align:left'><span>CreateAction</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">actionStatus<span>&nbsp;</span><a href="http://schema.org/actionStatus">[?]</a></th>
-            <td style='text-align:left'><a href="http://schema.org/CompleteActionStatus">http://schema.org/CompleteActionStatus</a></td>
+            <td style='text-align:left'><a href="http://schema.org/CompletedActionStatus">http://schema.org/CompletedActionStatus</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">agent<span>&nbsp;</span><a href="http://schema.org/agent">[?]</a></th>
             <td style='text-align:left'><a href="#https%3A//orcid.org/0000-0001-9842-9718">Stian Soiland-Reyes</a></td>


### PR DESCRIPTION
Most instances of `CompletedActionStatus` are spelled correctly, but there are a few instances which use the mis-spelling `CompleteActionStatus` (which doesn't resolve)